### PR TITLE
Adding PR checks for tests and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Run Jest Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Jest tests
+        run: npm run test
+
+  build:
+    name: Check TypeScript Build
+    runs-on: ubuntu-latest
+    needs: test  # Only runs if the 'test' job succeeds
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run TypeScript build
+        run: npm run build --if-present

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,9 +1,9 @@
 import { FaSearch } from 'react-icons/fa'
 import { FaCodeCompare } from 'react-icons/fa6'
 import { Link } from 'react-router'
-import { getTypeByName } from '../../utils/pokemonTypes'
-import { IoAppsSharp } from 'react-icons/io5'
 import { LuSwords } from 'react-icons/lu'
+import { IoAppsSharp } from 'react-icons/io5'
+import { getTypeByName } from '@/utils/pokemonUtils'
 
 const apps = [
   {

--- a/src/pages/Pokemon/index.tsx
+++ b/src/pages/Pokemon/index.tsx
@@ -9,11 +9,11 @@ import { FaAngleRight, FaAngleLeft } from 'react-icons/fa6'
 import { FaFastForward } from 'react-icons/fa'
 import { RiBattery2ChargeFill } from 'react-icons/ri'
 import { convertInfoHeader } from '@/data/types'
-import { getTypeByName } from '@/utils/pokemonTypes'
 import { renderEvChain } from '@/utils/renderEvChain'
 import { usePokemonById } from '@/hooks/usePokemon'
 import { useRanks } from '@/hooks/useRanks'
 import { useState } from 'react'
+import { getTypeByName } from '@/utils/pokemonUtils'
 
 export default function PokemonInfo() {
   const { id } = useParams()


### PR DESCRIPTION
This pull request includes updates to the CI workflow configuration and refactors import paths in the `Home` and `Pokemon` pages. The changes aim to improve the CI process and maintain consistency in utility imports.

### CI Workflow Configuration:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R48): Added a new CI workflow with jobs for running Jest tests and checking the TypeScript build.

### Codebase Refactoring:
* [`src/pages/Home/index.tsx`](diffhunk://#diff-5a6f0253e539f179f0fc93e6a544f64792aa493499976e4bbf3a45059a83a514L4-R6): Refactored import path for `getTypeByName` to `@/utils/pokemonUtils` for consistency.
* [`src/pages/Pokemon/index.tsx`](diffhunk://#diff-2e73fd0eaa887351760ab62bd5af702f5284ae84e354a3eb344d216b5e42abdeL12-R16): Refactored import path for `getTypeByName` to `@/utils/pokemonUtils` for consistency.