### PR TITLE
removing raid info for now

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,9 +1,9 @@
 import { FaSearch } from 'react-icons/fa'
 import { FaCodeCompare } from 'react-icons/fa6'
 import { Link } from 'react-router'
-import { LuSwords } from 'react-icons/lu'
 import { IoAppsSharp } from 'react-icons/io5'
 import { getTypeByName } from '@/utils/pokemonUtils'
+// import { LuSwords } from 'react-icons/lu'
 
 const apps = [
   {
@@ -18,12 +18,12 @@ const apps = [
     description: 'Search for a Pokemon by name or ID',
     route: '/search',
   },
-  {
-    title: 'Current Raids',
-    icon: <LuSwords />,
-    description: 'Current Pokemon Go raids',
-    route: '/current-raids',
-  },
+  // {
+  //   title: 'Current Raids',
+  //   icon: <LuSwords />,
+  //   description: 'Current Pokemon Go raids',
+  //   route: '/current-raids',
+  // },
   {
     title: 'Other Apps',
     icon: <IoAppsSharp />,

--- a/src/pages/Other/index.tsx
+++ b/src/pages/Other/index.tsx
@@ -6,11 +6,11 @@ const otherApps = [
     description: 'A simple size chart app',
     link: '/size-chart',
   },
-  {
-    title: 'PoGo Raids',
-    description: 'Current raids in Pokémon Go',
-    link: '/current-raids',
-  },
+  // {
+  //   title: 'PoGo Raids',
+  //   description: 'Current raids in Pokémon Go',
+  //   link: '/current-raids',
+  // },
 ]
 
 export default function OtherAppsPage() {


### PR DESCRIPTION
This pull request includes changes to the `Home` and `Other` pages to temporarily remove the "Current Raids" feature. The most important changes include commenting out the import statement and the corresponding section in the `apps` array on the `Home` page, as well as commenting out the relevant section in the `otherApps` array on the `Other` page.

Changes to `Home` page:

* [`src/pages/Home/index.tsx`](diffhunk://#diff-5a6f0253e539f179f0fc93e6a544f64792aa493499976e4bbf3a45059a83a514L4-R6): Commented out the import statement for `LuSwords` from `react-icons/lu` and the "Current Raids" section in the `apps` array. [[1]](diffhunk://#diff-5a6f0253e539f179f0fc93e6a544f64792aa493499976e4bbf3a45059a83a514L4-R6) [[2]](diffhunk://#diff-5a6f0253e539f179f0fc93e6a544f64792aa493499976e4bbf3a45059a83a514L21-R26)

Changes to `Other` page:

* [`src/pages/Other/index.tsx`](diffhunk://#diff-96245ea9b141d3aa7e4315e45c5514d9ed2334dabe679730273f8fc7feca44e9L9-R13): Commented out the "PoGo Raids" section in the `otherApps` array.