### PR TITLE
quick fix

### DIFF
--- a/src/pages/Pokemon/index.tsx
+++ b/src/pages/Pokemon/index.tsx
@@ -16,6 +16,7 @@ import { usePokemonById } from '@/hooks/usePokemon'
 import { useRanks } from '@/hooks/useRanks'
 import { useState } from 'react'
 import { getTypeByName } from '@/utils/pokemonUtils'
+import { canMega } from '@/utils/canMega'
 
 type TPokemonForms = 'normal' | 'mega' | 'shiny'
 
@@ -55,6 +56,8 @@ export default function PokemonInfo() {
     shiny: pokemon.sprites.other.home.front_shiny,
     mega: `https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${pokemon.id}-Mega.png`,
   }
+
+  const canMegaEvolve = canMega(pokemon.name)
 
   return (
     <div className="pb-16 pt-8 flex flex-col gap-8">
@@ -123,12 +126,14 @@ export default function PokemonInfo() {
           >
             {imageType === 'shiny' ? <IoSparkles /> : <IoSparklesOutline />}
           </button>
-          <button
-            className={clsx({ 'text-yellow-300': imageType === 'mega' })}
-            onClick={() => setImageType(imageType === 'mega' ? 'normal' : 'mega')}
-          >
-            <PiDnaFill />
-          </button>
+          {canMegaEvolve && (
+            <button
+              className={clsx({ 'text-yellow-300': imageType === 'mega' })}
+              onClick={() => setImageType(imageType === 'mega' ? 'normal' : 'mega')}
+            >
+              <PiDnaFill />
+            </button>
+          )}
         </div>
       </header>
 


### PR DESCRIPTION
This pull request introduces functionality to conditionally display a button for Mega Evolution in the `PokemonInfo` component. The changes include importing a utility function, adding a new variable to determine if Mega Evolution is possible, and updating the UI to reflect this condition.

### Functional Updates:

* **Added Mega Evolution Logic**:
  - Imported the `canMega` utility function from `@/utils/canMega` to determine if a Pokémon can Mega Evolve.
  - Introduced a `canMegaEvolve` variable in the `PokemonInfo` component to store the result of the `canMega` function based on the Pokémon's name.

* **Conditional Rendering of Mega Evolution Button**:
  - Updated the UI to conditionally render the Mega Evolution button only if `canMegaEvolve` is `true`. This ensures the button is only shown for Pokémon capable of Mega Evolution.